### PR TITLE
Remove extra blank line in convert_hdr_to_sdr.sh

### DIFF
--- a/convert_hdr_to_sdr.sh
+++ b/convert_hdr_to_sdr.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-
 for file in $PWD/*
 do
   if [[ $file != *"convert_hdr"* && $file != *"ffmpeg"* ]]; then


### PR DESCRIPTION
Removed extra blank line in convert_hdr_to_sdr.sh

This highly improves readability for future contributors. After this change you won't have to move your eyes so far down just to look at the next line.